### PR TITLE
ci: use selfhosted runners

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,13 +25,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Update apt cache
-        run: apt-get update
-      - name: Install Libudev
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: libudev-dev
-          version: 1.0
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y libudev-dev
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
         with:
@@ -48,13 +45,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Update apt cache
-        run: apt-get update
-      - name: Install Libudev
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: libudev-dev
-          version: 1.0
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y libudev-dev
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated workflow to run Rust jobs on self-hosted runners.
  - Improved Rust dependency caching for faster job execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->