### PR TITLE
feat: introduce a minimum deposit amount in configuration

### DIFF
--- a/contract/src/deposit.rs
+++ b/contract/src/deposit.rs
@@ -80,6 +80,10 @@ impl AuroraLaunchpadContract {
 
     fn handle_deposit(&mut self, amount: U128, msg: &str) -> PromiseOrValue<U128> {
         require!(self.is_ongoing(), "Launchpad is not ongoing");
+        require!(
+            amount >= self.config.min_deposit,
+            "Deposit amount is too low"
+        );
 
         // Get IntentsAccount from the message
         let account: IntentsAccount = msg.try_into().unwrap_or_else(|e| {

--- a/contract/src/tests/utils.rs
+++ b/contract/src/tests/utils.rs
@@ -14,6 +14,7 @@ pub const TEN_DAYS: u64 = 10 * 24 * 60 * 60;
 pub fn base_config(mechanics: Mechanics) -> LaunchpadConfig {
     LaunchpadConfig {
         deposit_token: DepositToken::Nep141(DEPOSIT_TOKEN_ID.parse().unwrap()),
+        min_deposit: 100_000.into(),
         sale_token_account_id: SALE_TOKEN_ID.parse().unwrap(),
         intents_account_id: INTENTS_ACCOUNT_ID.parse().unwrap(),
         start_date: NOW,

--- a/tests/src/env/mod.rs
+++ b/tests/src/env/mod.rs
@@ -151,6 +151,7 @@ impl Env {
 
         LaunchpadConfig {
             deposit_token: DepositToken::Nep141(self.deposit_ft.id().clone()),
+            min_deposit: 100.into(),
             sale_token_account_id: self.sale_token.id().clone(),
             intents_account_id: self.defuse.id().clone(),
             start_date: now,
@@ -179,6 +180,7 @@ impl Env {
                 self.deposit_mt.id().clone(),
                 format!("nep141:{}", self.deposit_ft.id()),
             )),
+            min_deposit: 100.into(),
             sale_token_account_id: self.sale_token.id().clone(),
             intents_account_id: self.defuse.id().clone(),
             start_date: now,

--- a/types/src/config.rs
+++ b/types/src/config.rs
@@ -16,6 +16,8 @@ use crate::utils::is_all_unique;
 pub struct LaunchpadConfig {
     /// The NEP-141 or NEP-245 token accepted for deposits. E.g.: `wrap.near`
     pub deposit_token: DepositToken,
+    /// Minimum deposit amount denominated in the deposit token.
+    pub min_deposit: U128,
     /// The account of the token used in the Sale.
     pub sale_token_account_id: AccountId,
     /// The account of the intents contract.
@@ -271,6 +273,7 @@ mod tests {
               "deposit_token": {
                 "Nep141": "17208628f84f5d6ad33f0da3bbbeb27ffcb398eac501a31bd6ad2011e36133a1"
               },
+              "min_deposit": "100000",
               "sale_token_account_id": "stjack.tkn.primitives.near",
               "intents_account_id": "intents.near",
               "start_date": "2025-05-04T12:00:00Z",
@@ -369,5 +372,6 @@ mod tests {
                 vesting: None,
             }
         );
+        assert_eq!(config.min_deposit, 100_000.into());
     }
 }

--- a/types/src/discount.rs
+++ b/types/src/discount.rs
@@ -77,6 +77,7 @@ mod tests {
         let mechanics = Mechanics::PriceDiscovery;
         LaunchpadConfig {
             deposit_token: DepositToken::Nep141(DEPOSIT_TOKEN_ID.parse().unwrap()),
+            min_deposit: U128(10u128.pow(24)),
             sale_token_account_id: SALE_TOKEN_ID.parse().unwrap(),
             intents_account_id: INTENTS_ACCOUNT_ID.parse().unwrap(),
             start_date: NOW,

--- a/types/src/tests.rs
+++ b/types/src/tests.rs
@@ -43,6 +43,7 @@ fn config_validation_zero_sale_token_in_price() {
 fn config() -> LaunchpadConfig {
     LaunchpadConfig {
         deposit_token: DepositToken::Nep141("token.near".parse().unwrap()),
+        min_deposit: 100.into(),
         sale_token_account_id: "sale.near".parse().unwrap(),
         intents_account_id: "intents.near".parse().unwrap(),
         start_date: 0,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added configurable minimum deposit enforcement. Projects can set a minimum deposit amount; any deposit below this threshold is rejected with a clear error.
  - Applies to all supported deposit token types. Failed deposits do not register participants, transfer funds, or alter totals.
  - Existing deposit flows remain unchanged for valid amounts.
  - Project owners should ensure their configurations include an appropriate minimum deposit to guide participants and prevent under-threshold contributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->