### PR TITLE
feat: possibility to add a full access key

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -3,11 +3,15 @@ use aurora_launchpad_types::config::{
     Mechanics, VestingSchedule,
 };
 use aurora_launchpad_types::{IntentsAccount, InvestmentAmount};
-use near_plugins::{AccessControlRole, AccessControllable, Pausable, Upgradable, access_control};
+use near_plugins::{
+    AccessControlRole, AccessControllable, Pausable, Upgradable, access_control, access_control_any,
+};
 use near_sdk::borsh::BorshDeserialize;
 use near_sdk::json_types::U128;
 use near_sdk::store::{LazyOption, LookupMap, LookupSet};
-use near_sdk::{AccountId, Gas, NearToken, PanicOnDefault, env, near};
+use near_sdk::{
+    AccountId, Gas, NearToken, PanicOnDefault, Promise, PublicKey, assert_one_yocto, env, near,
+};
 
 use crate::storage_key::StorageKey;
 
@@ -113,7 +117,7 @@ impl AuroraLaunchpadContract {
             acl.grant_role_unchecked(Role::Admin, &admin_account_id);
         } else {
             acl.add_super_admin_unchecked(&env::signer_account_id());
-            acl.grant_role_unchecked(Role::Admin, &env::current_account_id());
+            acl.grant_role_unchecked(Role::Admin, &env::signer_account_id());
         }
 
         contract
@@ -255,5 +259,12 @@ impl AuroraLaunchpadContract {
     #[must_use]
     pub const fn get_version() -> &'static str {
         VERSION
+    }
+
+    #[payable]
+    #[access_control_any(roles(Role::Admin))]
+    pub fn add_full_access_key(&mut self, public_key: PublicKey) -> Promise {
+        assert_one_yocto();
+        Promise::new(env::current_account_id()).add_full_access_key(public_key)
     }
 }

--- a/tests/src/tests/factory.rs
+++ b/tests/src/tests/factory.rs
@@ -1,3 +1,7 @@
+use near_sdk::NearToken;
+use near_sdk::serde_json::json;
+use near_workspaces::types::{KeyType, SecretKey};
+
 use crate::env::Env;
 use crate::env::sale_contract::SaleContract;
 
@@ -23,4 +27,46 @@ async fn create_via_factory_with_invalid_config() {
 
     let result = env.create_launchpad(&config).await.unwrap_err();
     assert!(result.to_string().contains("The Total sale amount must be equal to the sale amount plus solver allocation and distribution allocations"));
+}
+
+#[tokio::test]
+async fn add_full_access_key() {
+    let env = Env::new().await.unwrap();
+    let alice = env.alice();
+    let public_key = SecretKey::from_random(KeyType::ED25519).public_key();
+    let config = env.create_config().await;
+    let contract = env
+        .create_launchpad_with_admin(&config, Some(alice.id()))
+        .await
+        .unwrap();
+
+    assert!(
+        !contract
+            .view_access_keys()
+            .await
+            .unwrap()
+            .iter()
+            .any(|a| a.public_key == public_key)
+    );
+
+    let result = alice
+        .call(contract.id(), "add_full_access_key")
+        .args_json(json!({
+            "public_key": public_key
+        }))
+        .max_gas()
+        .deposit(NearToken::from_yoctonear(1))
+        .transact()
+        .await
+        .unwrap();
+    assert!(result.is_success(), "{result:#?}");
+
+    assert!(
+        contract
+            .view_access_keys()
+            .await
+            .unwrap()
+            .iter()
+            .any(|a| a.public_key == public_key)
+    );
 }

--- a/tests/src/tests/withdraw/near.rs
+++ b/tests/src/tests/withdraw/near.rs
@@ -7,6 +7,7 @@ use crate::env::sale_contract::{Deposit, SaleContract, Withdraw};
 use aurora_launchpad_types::config::Mechanics;
 use aurora_launchpad_types::discount::Discount;
 use near_sdk::NearToken;
+use near_sdk::serde_json::json;
 use near_workspaces::operations::Function;
 
 #[tokio::test]
@@ -627,6 +628,20 @@ async fn withdraw_in_locked_mode() {
 
     let lp = env.create_launchpad(&config).await.unwrap();
     let alice = env.alice();
+
+    // Grant the Admin role to the account id of the launchpad
+    let result = env
+        .factory
+        .as_account()
+        .call(lp.id(), "acl_grant_role")
+        .args_json(json!({
+            "role": "Admin",
+            "account_id": lp.id()
+        }))
+        .transact()
+        .await
+        .unwrap();
+    assert!(result.is_success());
 
     env.sale_token.storage_deposit(lp.id()).await.unwrap();
     env.sale_token


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can add a full-access key to the contract via a payable call; requires exactly 1 yoctoNEAR and admin authorization.
  * When no admin is supplied at initialization, the transaction signer is assigned admin.

* **Tests**
  * Added tests for the key-addition flow and updated tests to grant admin role where needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->