### PR TITLE
ci: switch GHA to RunsOn

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,13 @@ name: Build
 jobs:
   build:
     name: Build contract
-    runs-on: selfhosted-heavy
+    runs-on: runs-on=${{ github.run_id }}/family=c6a.8xlarge/image=ubuntu24-full-x64/extras=s3-cache
     container: rust:latest
     steps:
+      - name: Setup RunsOn
+        uses: runs-on/action@v2
+        with:
+          metrics: cpu,network,memory,disk,io
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install dependencies
@@ -37,7 +41,7 @@ jobs:
 
   publish:
     name: Publish contracts
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/family=c6a.large/image=ubuntu24-full-x64
     needs: build
     steps:
       - name: Download artifacts

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,9 +12,11 @@ env:
 jobs:
   formatting:
     name: Code Formatting
-    runs-on: selfhosted
+    runs-on: runs-on=${{ github.run_id }}/family=c6a.4xlarge/image=ubuntu24-full-x64/extras=s3-cache
     container: rust:latest
     steps:
+      - name: Setup RunsOn
+        uses: runs-on/action@v2
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Setup Rust cache
@@ -27,9 +29,11 @@ jobs:
 
   linter:
     name: Code Linter
-    runs-on: selfhosted
+    runs-on: runs-on=${{ github.run_id }}/family=c6a.4xlarge/image=ubuntu24-full-x64/extras=s3-cache
     container: rust:latest
     steps:
+      - name: Setup RunsOn
+        uses: runs-on/action@v2
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install dependencies
@@ -47,9 +51,13 @@ jobs:
 
   tests:
     name: Tests
-    runs-on: selfhosted-heavy
+    runs-on: runs-on=${{ github.run_id }}/family=c6a.8xlarge/image=ubuntu24-full-x64/extras=s3-cache
     container: rust:latest
     steps:
+      - name: Setup RunsOn
+        uses: runs-on/action@v2
+        with:
+          metrics: cpu,network,memory,disk,io
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install dependencies


### PR DESCRIPTION
This PR moves the CI infra to [RunsOn](https://runs-on.com), which runs GitHub Actions workflows on AWS EC2 C6a [Spot Instances](https://aws.amazon.com/ec2/spot/). By using Spot, we cut costs by around 90% compared to GitHub-hosted runners or other major managed options.

We’re also using the RunsOn bootstrap service action to add inline performance stats and spin up a sidecar that transparently intercepts GitHub Cache API calls and routes them to our S3 bucket. That gives us much faster caching and removes the 10GB per-repo limit.

Instance types in use for this repo:

* `c6a.8xlarge` (32 vCPU / 64 GiB) and `c6a.4xlarge` (16 vCPU / 32 GiB) for Rust CI jobs
* `c6a.large` (2 vCPU / 4 GiB) for the `Publish contracts` job

Feel free to adjust instance sizes as needed based on the table [here](https://aws.amazon.com/ec2/instance-types/c6a/).

---

@coderabbitai ignore