### PR TITLE
fix: distribute sale tokens with zero allocation for solver

### DIFF
--- a/contract/src/distribute/sale.rs
+++ b/contract/src/distribute/sale.rs
@@ -177,6 +177,7 @@ impl AuroraLaunchpadContract {
                     }
                 }),
         )
+        .filter(|(_, amount)| amount.0 > 0)
         .filter_map(|(account, amount)| {
             self.distributed_accounts.get(account).map_or(
                 Some((account, *amount)),

--- a/tests/src/tests/distribution/sale/intents.rs
+++ b/tests/src/tests/distribution/sale/intents.rs
@@ -697,3 +697,111 @@ async fn distribution_with_partial_refunds_max_stakeholders() {
             .contains("Tokens have been already distributed")
     );
 }
+
+#[tokio::test]
+async fn successful_distribution_with_zero_allocation_for_solver() {
+    let env = Env::new().await.unwrap();
+    let mut config = env.create_config().await;
+    let solver_account_id: AccountId = "solver.near".parse().unwrap();
+    let stakeholder1_account_id: AccountId = "stakeholder1.near".parse().unwrap();
+    let stakeholder2_account_id: AccountId = "stakeholder2.near".parse().unwrap();
+
+    config.soft_cap = 100_000.into();
+    config.sale_amount = 100_000.into();
+    config.distribution_proportions = DistributionProportions {
+        solver_account_id: DistributionAccount::new_intents(solver_account_id.clone()).unwrap(),
+        solver_allocation: 0.into(),
+        stakeholder_proportions: vec![
+            StakeholderProportion {
+                account: DistributionAccount::new_intents(stakeholder1_account_id.clone()).unwrap(),
+                allocation: 50_000.into(),
+                vesting: None,
+            },
+            StakeholderProportion {
+                account: DistributionAccount::new_intents(stakeholder2_account_id.clone()).unwrap(),
+                allocation: 50_000.into(),
+                vesting: None,
+            },
+        ],
+        deposits: None,
+    };
+
+    let lp = env.create_launchpad(&config).await.unwrap();
+    let alice = env.alice();
+
+    env.sale_token
+        .storage_deposits(&[lp.id(), env.defuse.id()])
+        .await
+        .unwrap();
+    env.sale_token
+        .ft_transfer_call(lp.id(), config.total_sale_amount, "")
+        .await
+        .unwrap();
+
+    env.deposit_ft
+        .storage_deposits(&[lp.id(), alice.id()])
+        .await
+        .unwrap();
+    env.deposit_ft
+        .ft_transfer(alice.id(), 100_000)
+        .await
+        .unwrap();
+
+    alice
+        .deposit_nep141(lp.id(), env.deposit_ft.id(), 100_000)
+        .await
+        .unwrap();
+
+    // An attempt to distribute tokens before the sale finishes.
+    let err = alice.distribute_sale_tokens(lp.id()).await.unwrap_err();
+    assert!(
+        err.to_string().contains(
+            "Distribution can be called only if the launchpad finishes with success status"
+        )
+    );
+
+    env.wait_for_sale_finish(&config).await;
+
+    assert_eq!(lp.get_status().await.unwrap(), "Success");
+
+    alice.distribute_sale_tokens(lp.id()).await.unwrap();
+
+    alice.claim_to_intents(lp.id(), alice.id()).await.unwrap();
+
+    let balance = env
+        .defuse
+        .mt_balance_of(alice.id(), format!("nep141:{}", env.sale_token.id()))
+        .await
+        .unwrap();
+    assert_eq!(balance, 100_000);
+
+    let balance = env
+        .defuse
+        .mt_balance_of(
+            &solver_account_id,
+            format!("nep141:{}", env.sale_token.id()),
+        )
+        .await
+        .unwrap();
+    assert_eq!(balance, 0);
+
+    let balance = env
+        .defuse
+        .mt_balance_of(
+            &stakeholder1_account_id,
+            format!("nep141:{}", env.sale_token.id()),
+        )
+        .await
+        .unwrap();
+    assert_eq!(balance, 50_000);
+
+    let balance = env
+        .defuse
+        .mt_balance_of(
+            &stakeholder2_account_id,
+            format!("nep141:{}", env.sale_token.id()),
+        )
+        .await
+        .unwrap();
+    assert_eq!(balance, 50_000);
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Distribution now skips zero or negative allocations, processing only positive amounts. Zero-allocation participants receive nothing while others are distributed as expected.

- Bug Fixes
  - Prevents unintended transfers and errors by excluding non-positive allocations from distribution.

- Tests
  - Added scenarios verifying successful distribution when the solver allocation is zero, confirming correct final balances for all participants and that zero-allocation accounts remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->