### PR TITLE
Increase GHA runner instance disk size for the test job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,7 +51,7 @@ jobs:
 
   tests:
     name: Tests
-    runs-on: runs-on=${{ github.run_id }}/family=c6a.8xlarge/image=ubuntu24-full-x64/extras=s3-cache
+    runs-on: runs-on=${{ github.run_id }}/family=c6a.8xlarge/image=ubuntu24-full-x64/disk=large/extras=s3-cache
     container: rust:latest
     steps:
       - name: Setup RunsOn


### PR DESCRIPTION
Fixes [such](https://github.com/aurora-is-near/aurora-launchpad-contracts/actions/runs/18493045237/job/52690929251?pr=50#step:9:556) behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Continuous integration test runners now provisioned with larger disk capacity.
  * Affects build infrastructure only; no changes to product functionality or user experience.
  * Build and test workflow steps remain the same; only the runner’s disk allocation changed.
  * No changes to features, APIs, or interfaces.
  * No user action required.
  * This release does not introduce new features or bug fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->