### PR TITLE
fix: ensure linked phases do not use capacity each other

### DIFF
--- a/contract/src/discount/state.rs
+++ b/contract/src/discount/state.rs
@@ -231,17 +231,8 @@ impl DiscountState {
 
             let sale_tokens_per_account =
                 existed_account_sale_tokens.saturating_add(sale_tokens_per_deposit);
-            let sale_tokens_for_prev_phases = self.get_total_sale_tokens_for_previous_phases(
-                *id,
-                &phase_weights,
-                deposit_token.0,
-                sale_token.0,
-                active_phase_ids,
-            )?;
-            let sale_tokens_per_phases = existed_phase_sale_tokens
-                .saturating_add(sale_tokens_for_prev_phases)
-                .saturating_add(sale_tokens_per_deposit);
-
+            let sale_tokens_per_phases =
+                existed_phase_sale_tokens.saturating_add(sale_tokens_per_deposit);
             let exceeded_account_limit =
                 phase_params.calculate_account_limit_exceeded(sale_tokens_per_account);
             let exceeded_phase_limit =
@@ -337,7 +328,7 @@ impl DiscountState {
         self.phases
             .iter()
             .filter(|(_, phase_state)| phase_state.limit_per_phase.is_some())
-            .filter(|(id, _)| **id == phase_id || self.is_linked_inactive(phase_id, **id, active))
+            .filter(|(id, _)| **id == phase_id || self.is_linked_available(phase_id, **id, active))
             .map(|(_, phase_state)| phase_state.total_sale_tokens)
             .sum()
     }
@@ -362,7 +353,7 @@ impl DiscountState {
         let total_limits = self
             .phases
             .iter()
-            .filter(|(id, _)| **id == phase_id || self.is_linked_inactive(phase_id, **id, active))
+            .filter(|(id, _)| **id == phase_id || self.is_linked_available(phase_id, **id, active))
             .map(|(_, phase_state)| phase_state.limit_per_phase.unwrap_or(0))
             .sum();
 
@@ -375,27 +366,30 @@ impl DiscountState {
             .is_some_and(|phases| phases.contains(&linked_id))
     }
 
-    /// A phase absorbs a linked predecessor's cap only when that predecessor is no longer active
-    /// (outside its `[start, end)` window). While active, a predecessor reserves its full cap for
-    /// itself, so simultaneously-active phases each respect only their own cap.
-    fn is_linked_inactive(&self, phase_id: u16, other_id: u16, active: &HashSet<u16>) -> bool {
-        self.is_phases_linked(phase_id, other_id) && !active.contains(&other_id)
+    fn is_linked_available(&self, phase_id: u16, other_id: u16, active: &HashSet<u16>) -> bool {
+        self.is_phases_linked(phase_id, other_id)
+            && !active.contains(&other_id)
+            && !self.is_reserved_by_active_intermediate(phase_id, other_id, active)
     }
 
-    fn get_total_sale_tokens_for_previous_phases(
+    fn is_reserved_by_active_intermediate(
         &self,
         phase_id: u16,
-        phase_weights: &[(u16, u128)],
-        deposit_token: u128,
-        sale_token: u128,
+        predecessor_id: u16,
         active: &HashSet<u16>,
-    ) -> Result<u128, &'static str> {
-        phase_weights
-            .iter()
-            .filter(|(prev_id, _)| self.is_linked_inactive(phase_id, *prev_id, active))
-            .try_fold(0u128, |acc, (_, prev_weight)| {
-                calculate_amount_of_sale_tokens(*prev_weight, deposit_token, sale_token)
-                    .and_then(|result| acc.checked_add(result).ok_or("Overflow occurred"))
+    ) -> bool {
+        self.linked_phases
+            .get(&phase_id)
+            .is_some_and(|predecessors| {
+                predecessors.iter().any(|intermediate_id| {
+                    *intermediate_id != predecessor_id
+                        && active.contains(intermediate_id)
+                        && self
+                            .phases
+                            .get(intermediate_id)
+                            .is_some_and(|phase_state| phase_state.limit_per_phase.is_some())
+                        && self.is_phases_linked(*intermediate_id, predecessor_id)
+                })
             })
     }
 }

--- a/contract/src/discount/state.rs
+++ b/contract/src/discount/state.rs
@@ -75,6 +75,17 @@ impl DiscountState {
                 return DepositDistribution::Refund(deposit);
             }
 
+            // Phases that are currently active in time. A linked predecessor may only have its cap
+            // absorbed by a later "sink" phase once it is no longer active; while active it reserves
+            // its full cap for itself. Time-based (not `percent_per_phase`-based) on purpose: a phase
+            // active-in-time but ineligible for this account still consumes global phase capacity for
+            // other accounts, so it must still reserve its cap.
+            let active_phase_ids: HashSet<u16> = discount_params
+                .get_phases_by_time(timestamp)
+                .iter()
+                .map(|phase| phase.id)
+                .collect();
+
             match self.calculate_deposit_distribution(
                 account,
                 deposit,
@@ -83,6 +94,7 @@ impl DiscountState {
                 discount_params,
                 available_for_sale,
                 is_public_sale_allowed,
+                &active_phase_ids,
             ) {
                 Ok(distribution) => distribution,
                 Err(e) => {
@@ -157,6 +169,7 @@ impl DiscountState {
         discount_params: &DiscountParams,
         available_for_sale: u128,
         is_public_sale_allowed: bool,
+        active_phase_ids: &HashSet<u16>,
     ) -> Result<DepositDistribution, &'static str> {
         match mechanics {
             Mechanics::FixedPrice { .. } => self.deposit_distribution_fixed_price(
@@ -167,6 +180,7 @@ impl DiscountState {
                 mechanics,
                 available_for_sale,
                 is_public_sale_allowed,
+                active_phase_ids,
             ),
             Mechanics::PriceDiscovery => {
                 deposit_distribution_price_discovery(percent_per_phase, deposit)
@@ -184,6 +198,7 @@ impl DiscountState {
         mechanics: Mechanics,
         available_for_sale: u128,
         is_public_sale_allowed: bool,
+        active_phase_ids: &HashSet<u16>,
     ) -> Result<DepositDistribution, &'static str> {
         let mut remain_deposit = deposit;
         let mut remain_available_for_sale = available_for_sale;
@@ -203,7 +218,8 @@ impl DiscountState {
             let phase_params = discount_params.get_phase_params_by_id(*id)?;
             let existed_account_sale_tokens = self.get_account_sale_tokens_for_phase(account, *id);
             // The number of sale tokens that were sold in the previous phases made in previous transactions.
-            let existed_phase_sale_tokens = self.get_total_sale_tokens_for_phases_with_limits(*id);
+            let existed_phase_sale_tokens =
+                self.get_total_sale_tokens_for_phases_with_limits(*id, active_phase_ids);
             let sale_tokens_per_deposit =
                 calculate_amount_of_sale_tokens(weight, deposit_token.0, sale_token.0)?;
 
@@ -220,6 +236,7 @@ impl DiscountState {
                 &phase_weights,
                 deposit_token.0,
                 sale_token.0,
+                active_phase_ids,
             )?;
             let sale_tokens_per_phases = existed_phase_sale_tokens
                 .saturating_add(sale_tokens_for_prev_phases)
@@ -228,7 +245,7 @@ impl DiscountState {
             let exceeded_account_limit =
                 phase_params.calculate_account_limit_exceeded(sale_tokens_per_account);
             let exceeded_phase_limit =
-                self.calculate_phase_limit_excess(sale_tokens_per_phases, *id);
+                self.calculate_phase_limit_excess(sale_tokens_per_phases, *id, active_phase_ids);
             let exceeded_global_limit =
                 sale_tokens_per_deposit.saturating_sub(remain_available_for_sale);
 
@@ -312,16 +329,25 @@ impl DiscountState {
             .unwrap_or(0)
     }
 
-    fn get_total_sale_tokens_for_phases_with_limits(&self, phase_id: u16) -> u128 {
+    fn get_total_sale_tokens_for_phases_with_limits(
+        &self,
+        phase_id: u16,
+        active: &HashSet<u16>,
+    ) -> u128 {
         self.phases
             .iter()
             .filter(|(_, phase_state)| phase_state.limit_per_phase.is_some())
-            .filter(|(id, _)| **id == phase_id || self.is_phases_linked(phase_id, **id))
+            .filter(|(id, _)| **id == phase_id || self.is_linked_inactive(phase_id, **id, active))
             .map(|(_, phase_state)| phase_state.total_sale_tokens)
             .sum()
     }
 
-    fn calculate_phase_limit_excess(&self, sale_tokens: u128, phase_id: u16) -> u128 {
+    fn calculate_phase_limit_excess(
+        &self,
+        sale_tokens: u128,
+        phase_id: u16,
+        active: &HashSet<u16>,
+    ) -> u128 {
         let current_phase_limit = self
             .phases
             .get(&phase_id)
@@ -336,7 +362,7 @@ impl DiscountState {
         let total_limits = self
             .phases
             .iter()
-            .filter(|(id, _)| **id == phase_id || self.is_phases_linked(phase_id, **id))
+            .filter(|(id, _)| **id == phase_id || self.is_linked_inactive(phase_id, **id, active))
             .map(|(_, phase_state)| phase_state.limit_per_phase.unwrap_or(0))
             .sum();
 
@@ -349,16 +375,24 @@ impl DiscountState {
             .is_some_and(|phases| phases.contains(&linked_id))
     }
 
+    /// A phase absorbs a linked predecessor's cap only when that predecessor is no longer active
+    /// (outside its `[start, end)` window). While active, a predecessor reserves its full cap for
+    /// itself, so simultaneously-active phases each respect only their own cap.
+    fn is_linked_inactive(&self, phase_id: u16, other_id: u16, active: &HashSet<u16>) -> bool {
+        self.is_phases_linked(phase_id, other_id) && !active.contains(&other_id)
+    }
+
     fn get_total_sale_tokens_for_previous_phases(
         &self,
         phase_id: u16,
         phase_weights: &[(u16, u128)],
         deposit_token: u128,
         sale_token: u128,
+        active: &HashSet<u16>,
     ) -> Result<u128, &'static str> {
         phase_weights
             .iter()
-            .filter(|(prev_id, _)| self.is_phases_linked(phase_id, *prev_id))
+            .filter(|(prev_id, _)| self.is_linked_inactive(phase_id, *prev_id, active))
             .try_fold(0u128, |acc, (_, prev_weight)| {
                 calculate_amount_of_sale_tokens(*prev_weight, deposit_token, sale_token)
                     .and_then(|result| acc.checked_add(result).ok_or("Overflow occurred"))

--- a/contract/src/tests/discount/fixed_price.rs
+++ b/contract/src/tests/discount/fixed_price.rs
@@ -355,6 +355,59 @@ fn use_max_phase_limits_to_walk_through_phases() {
 }
 
 #[test]
+fn simultaneously_active_linked_phases_each_respect_own_cap() {
+    let price = fixed_price(1, 1);
+    let mut config = base_config(price);
+
+    config.discounts = Some(DiscountParams {
+        phases: vec![
+            DiscountPhase {
+                id: 0,
+                start_time: 10,
+                end_time: 15,
+                percentage: 1000,
+                phase_sale_limit: Some(1000.into()),
+                ..Default::default()
+            },
+            DiscountPhase {
+                id: 1,
+                start_time: 10,
+                end_time: 15,
+                percentage: 3000,
+                phase_sale_limit: Some(1000.into()),
+                ..Default::default()
+            },
+            DiscountPhase {
+                id: 2,
+                start_time: 10,
+                end_time: 15,
+                percentage: 2000,
+                phase_sale_limit: Some(1000.into()),
+                ..Default::default()
+            },
+        ],
+        public_sale_start_time: Some(15),
+    });
+
+    let ctx = TestContext::new(config);
+    let deposit = 4000;
+    let deposit_distribution = ctx
+        .contract()
+        .get_deposit_distribution(ctx.alice(), deposit, 11);
+
+    // 1000 tokens from each phase (each respects its own cap), no public sale (starts at t=15).
+    // Refund: 4000 - 1000*10000/13000 - 1000*10000/12000 - 1000*10000/11000 = 4000 - 769 - 833 - 909 = 1489
+    assert_eq!(
+        deposit_distribution,
+        DepositDistribution::WithDiscount {
+            phase_weights: vec![(1, 1000), (2, 1000), (0, 1000)],
+            public_sale_weight: 0,
+            refund: 1489,
+        }
+    );
+}
+
+#[test]
 fn refund_reach_global_sale_amount() {
     let price = fixed_price(1, 2);
     let mut config = base_config(price);

--- a/contract/src/tests/discount/fixed_price.rs
+++ b/contract/src/tests/discount/fixed_price.rs
@@ -408,6 +408,141 @@ fn simultaneously_active_linked_phases_each_respect_own_cap() {
 }
 
 #[test]
+fn active_intermediate_phase_reserves_inherited_cap_for_overlapping_sink() {
+    let price = fixed_price(1, 1);
+    let mut config = base_config(price);
+
+    config.discounts = Some(DiscountParams {
+        phases: vec![
+            DiscountPhase {
+                id: 0,
+                start_time: 10,
+                end_time: 12,
+                percentage: 0,
+                phase_sale_limit: Some(1000.into()),
+                remaining_go_to_phase_id: Some(1),
+                ..Default::default()
+            },
+            DiscountPhase {
+                id: 1,
+                start_time: 12,
+                end_time: 20,
+                percentage: 1000,
+                whitelist: Some(std::iter::once(alice().into()).collect()),
+                phase_sale_limit: Some(1000.into()),
+                remaining_go_to_phase_id: Some(2),
+                ..Default::default()
+            },
+            DiscountPhase {
+                id: 2,
+                start_time: 13,
+                end_time: 20,
+                percentage: 0,
+                phase_sale_limit: Some(1000.into()),
+                ..Default::default()
+            },
+        ],
+        public_sale_start_time: Some(20),
+    });
+
+    let ctx = TestContext::new(config);
+
+    let deposit_distribution = ctx
+        .contract()
+        .get_deposit_distribution(ctx.alice(), 1819, 13);
+    assert_eq!(
+        deposit_distribution,
+        DepositDistribution::WithDiscount {
+            phase_weights: vec![(1, 2000)],
+            public_sale_weight: 0,
+            refund: 0,
+        }
+    );
+
+    ctx.contract_mut()
+        .update_discount_state(ctx.alice(), &deposit_distribution, price);
+    ctx.contract_mut().total_sold_tokens = 2000;
+
+    let deposit_distribution = ctx.contract().get_deposit_distribution(ctx.bob(), 2000, 14);
+
+    assert_eq!(
+        deposit_distribution,
+        DepositDistribution::WithDiscount {
+            phase_weights: vec![(2, 1000)],
+            public_sale_weight: 0,
+            refund: 1000,
+        }
+    );
+}
+
+#[test]
+fn active_uncapped_intermediate_does_not_reserve_inherited_cap_for_overlapping_sink() {
+    let price = fixed_price(1, 1);
+    let mut config = base_config(price);
+
+    config.discounts = Some(DiscountParams {
+        phases: vec![
+            DiscountPhase {
+                id: 0,
+                start_time: 10,
+                end_time: 12,
+                percentage: 0,
+                phase_sale_limit: Some(1000.into()),
+                remaining_go_to_phase_id: Some(1),
+                ..Default::default()
+            },
+            DiscountPhase {
+                id: 1,
+                start_time: 12,
+                end_time: 20,
+                percentage: 1000,
+                whitelist: Some(std::iter::once(alice().into()).collect()),
+                remaining_go_to_phase_id: Some(2),
+                ..Default::default()
+            },
+            DiscountPhase {
+                id: 2,
+                start_time: 13,
+                end_time: 20,
+                percentage: 0,
+                phase_sale_limit: Some(1000.into()),
+                ..Default::default()
+            },
+        ],
+        public_sale_start_time: Some(20),
+    });
+
+    let ctx = TestContext::new(config);
+
+    let deposit_distribution = ctx
+        .contract()
+        .get_deposit_distribution(ctx.alice(), 1000, 13);
+    assert_eq!(
+        deposit_distribution,
+        DepositDistribution::WithDiscount {
+            phase_weights: vec![(1, 1100)],
+            public_sale_weight: 0,
+            refund: 0,
+        }
+    );
+
+    ctx.contract_mut()
+        .update_discount_state(ctx.alice(), &deposit_distribution, price);
+    ctx.contract_mut().total_sold_tokens = 1100;
+
+    let deposit_distribution = ctx.contract().get_deposit_distribution(ctx.bob(), 2000, 14);
+
+    assert_eq!(
+        deposit_distribution,
+        DepositDistribution::WithDiscount {
+            phase_weights: vec![(2, 2000)],
+            public_sale_weight: 0,
+            refund: 0,
+        }
+    );
+}
+
+#[test]
 fn refund_reach_global_sale_amount() {
     let price = fixed_price(1, 2);
     let mut config = base_config(price);

--- a/tests/src/tests/deposit/discount.rs
+++ b/tests/src/tests/deposit/discount.rs
@@ -4,7 +4,7 @@ use aurora_launchpad_types::discount::{DiscountParams, DiscountPhase};
 use crate::env::Env;
 use crate::env::fungible_token::FungibleToken;
 use crate::env::mt_token::MultiToken;
-use crate::env::sale_contract::{Deposit, SaleContract, WhiteListManage};
+use crate::env::sale_contract::{Claim, Deposit, SaleContract, WhiteListManage};
 use crate::tests::NANOSECONDS_PER_SECOND;
 
 #[tokio::test]
@@ -1319,5 +1319,115 @@ async fn max_account_limit_distributed_between_discount_and_public_sale_with_pas
     assert_eq!(
         lp.get_available_for_claim(bob.id()).await.unwrap(),
         2400 + 1200
+    );
+}
+
+#[tokio::test]
+async fn linked_phase_destination_processed_before_source_claims_extra_tokens() {
+    let env = Env::new().await.unwrap();
+    let mut config = env.create_config().await;
+
+    let alice = env.alice();
+    let now = env.current_timestamp().await;
+
+    config.start_date = now;
+
+    let duration = 30 * NANOSECONDS_PER_SECOND;
+
+    config.end_date = now + duration;
+    config.mechanics = Mechanics::FixedPrice {
+        deposit_token: 1.into(),
+        sale_token: 1.into(),
+    };
+
+    // Phase 0 sends its unused capacity to phase 1, but both phases are active at
+    // the same time and phase 1 has the higher discount. The production sorter
+    // processes phase 1 first, so phase 1 can consume phase 0's linked capacity
+    // before phase 0 itself is processed in the same deposit.
+    config.discounts = Some(DiscountParams {
+        phases: vec![
+            DiscountPhase {
+                id: 0,
+                start_time: config.start_date,
+                end_time: config.end_date,
+                percentage: 1000,
+                phase_sale_limit: Some(1000.into()),
+                remaining_go_to_phase_id: Some(1),
+                ..Default::default()
+            },
+            DiscountPhase {
+                id: 1,
+                start_time: config.start_date,
+                end_time: config.end_date,
+                percentage: 3000,
+                phase_sale_limit: Some(1000.into()),
+                ..Default::default()
+            },
+            DiscountPhase {
+                id: 2,
+                start_time: config.start_date,
+                end_time: config.end_date,
+                percentage: 2000,
+                phase_sale_limit: Some(1000.into()),
+                ..Default::default()
+            },
+        ],
+        public_sale_start_time: Some(config.end_date),
+    });
+    config.soft_cap = 1_000.into();
+    config.sale_amount = 10_000.into();
+    config.total_sale_amount = config.sale_amount;
+
+    let lp = env.create_launchpad(&config).await.unwrap();
+
+    env.sale_token
+        .storage_deposits(&[lp.id(), alice.id(), env.defuse.id()])
+        .await
+        .unwrap();
+    env.sale_token
+        .ft_transfer_call(lp.id(), config.total_sale_amount, "")
+        .await
+        .unwrap();
+
+    env.deposit_ft
+        .storage_deposits(&[lp.id(), alice.id(), env.defuse.id()])
+        .await
+        .unwrap();
+    env.deposit_ft.ft_transfer(alice.id(), 4_000).await.unwrap();
+
+    alice
+        .deposit_nep141(lp.id(), env.deposit_ft.id(), 4_000)
+        .await
+        .unwrap();
+
+    // The three linked phase caps are 1,000 + 1,000 + 1,000 sale tokens.
+    // Both phases are active, so each reserves only its own cap:
+    // Alice gets exactly 1,000 + 1,000 + 1,000 = 3,000 sale tokens before
+    // the public sale starts.
+    let available = lp.get_available_for_claim(alice.id()).await.unwrap();
+    assert_eq!(available, 3_000);
+
+    // The deposit path accepted 2,511 deposit tokens (1000*10000/13000 = 769 for the 30% phase
+    // plus 1000*10000/12000 = 833 for the 20% phase plus 1000*10000/11000 = 909 for the 10% phase)
+    // and refunded the rest: 4,000 - 2,511 = 1,489.
+    assert_eq!(
+        env.defuse
+            .mt_balance_of(alice.id(), format!("nep141:{}", env.deposit_ft.id()))
+            .await
+            .unwrap(),
+        1_489
+    );
+
+    env.wait_for_sale_finish(&config).await;
+    assert_eq!(lp.get_status().await.unwrap(), "Success");
+
+    alice
+        .claim_to_near(lp.id(), &env, alice.id(), available)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        env.sale_token.ft_balance_of(alice.id()).await.unwrap(),
+        available
     );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed discount allocation so active linked phases now respect their own caps when multiple phases are open at the same time.
  * Improved how unused capacity is shared across linked phases, leading to more accurate refunds and claimable token amounts.
  * Corrected fixed-price deposit calculations to avoid overcounting sale limits when related phases are still active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->